### PR TITLE
Add default value for route & direction filters

### DIFF
--- a/src/app/echtzeit/DirectionFilter.tsx
+++ b/src/app/echtzeit/DirectionFilter.tsx
@@ -58,6 +58,7 @@ export default function DirectionFilter({ stop }: { stop: NormalizedKVGStops }) 
 					router.push(pathname + '?' + createQueryString('direction', e.target.value));
 				}
 			}}
+			defaultValue={direction}
 		>
 			{directions.map((_direction) => (
 				<option key={_direction} value={_direction}>

--- a/src/app/echtzeit/RouteFilter.tsx
+++ b/src/app/echtzeit/RouteFilter.tsx
@@ -53,6 +53,7 @@ export default function RouteFilter({ stop }: { stop: NormalizedKVGStops }) {
 					router.push(pathname + '?' + createQueryString('routeId', e.target.value));
 				}
 			}}
+			defaultValue={routeId ?? defaultRoute.id}
 		>
 			{routes.map((route) => (
 				<option key={route.id} value={route.id}>


### PR DESCRIPTION
Add a default value for the route & direction filters so it represents the correct state on page reload